### PR TITLE
Fix comment delete route and enable authentication

### DIFF
--- a/BlogApp.Api/Controllers/CommentController.cs
+++ b/BlogApp.Api/Controllers/CommentController.cs
@@ -57,7 +57,7 @@ namespace BlogApp.Api.Controllers
         }
 
 
-        [HttpDelete("{blogId}/{id}")]
+        [HttpDelete("{blogId}/{commentId}")]
         public async Task<IActionResult> Delete(int blogId, int commentId)
         {
             var blog = await _blogService.GetByIdAsync(blogId);

--- a/BlogApp.Api/Program.cs
+++ b/BlogApp.Api/Program.cs
@@ -63,6 +63,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- fix mismatch between route and parameter in `CommentController.Delete`
- add missing `UseAuthentication()` call to API program

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0885d8083319a09eb7bbc5432e4