### PR TITLE
Fix MudBlazor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-stack blog application built with **Blazor WebAssembly (.NET 8)** for the
 - **Commenting System**: Users can open a blog post and leave comments, similar to social media.
 - **News Feed**: Blog posts are displayed as a list on the homepage.
 - **Search Functionality**: Search blog posts by title.
-- **Modern UI**: Built using the partily MudBlazor library.
+- **Modern UI**: Built using the partially MudBlazor library.
 
 ## Blog Post Details
 


### PR DESCRIPTION
## Summary
- fix a small typo in the main README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c1ac95ec83318f6978f978472b80