### PR TITLE
Update README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Each blog post contains:
 
 1. **Clone the Repository**:
    ```bash
-   git clone https://github.com/your-repo-name/BlogApp.git
-   cd BlogApp
+   git clone https://github.com/your-repo-name/BlogAppBlazor.git
+   cd BlogAppBlazor
    ```
 
 2. **Configure the Database**:


### PR DESCRIPTION
## Summary
- fix cloning commands in Setup Instructions of `README.md` to reference the correct repository directory

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c22261148331b1858a124361bbe7