### PR TITLE
Add test for BlogService empty search term

### DIFF
--- a/BlogApp.UnitTests/BlogServiceTests.cs
+++ b/BlogApp.UnitTests/BlogServiceTests.cs
@@ -156,6 +156,21 @@ namespace BlogApp.UnitTests
         }
 
         [Fact]
+        public async Task Search_ShouldThrow_WhenTermIsEmpty()
+        {
+            // Arrange
+            var dbName = Guid.NewGuid().ToString();
+            var context = GetInMemoryDbContext(dbName);
+            context.Blogs.Add(new Blog { Name = "Sample" });
+            await context.SaveChangesAsync();
+
+            var service = new BlogService(context, _mapper);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await service.Search(string.Empty));
+        }
+
+        [Fact]
         public async Task GetTotal_ShouldReturnCount()
         {
             // Arrange


### PR DESCRIPTION
## Summary
- extend BlogService unit tests
- add `Search_ShouldThrow_WhenTermIsEmpty` to ensure empty search terms raise `ArgumentException`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c22486488331a5c41bd7506e8b0c