### PR TITLE
Add validation attributes and tests

### DIFF
--- a/BlogApp.Api/Controllers/AuthController.cs
+++ b/BlogApp.Api/Controllers/AuthController.cs
@@ -22,6 +22,10 @@ namespace BlogApp.Api.Controllers
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
             var user = await _userManager.FindByNameAsync(request.Username);
             var loginResult = await _userManager.CheckPasswordAsync(user, request.Password);
             if (loginResult)
@@ -35,6 +39,10 @@ namespace BlogApp.Api.Controllers
         [HttpPost("register")]
         public async Task<IActionResult> Register([FromBody] RegisterRequestDto request)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
             try
             {
                 var result = await _userManager.CreateAsync(new ApplicationUser

--- a/BlogApp.Api/Controllers/BlogController.cs
+++ b/BlogApp.Api/Controllers/BlogController.cs
@@ -51,6 +51,10 @@ namespace BlogApp.Api.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody] BlogDtoCreate blog)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
             var currentUser = await _userManager.FindByNameAsync(User.Identity.Name);
             return Ok(await _blogService.AddAsync(blog, currentUser.Id));
         }
@@ -59,6 +63,10 @@ namespace BlogApp.Api.Controllers
         [HttpPut("{id}")]
         public async Task<IActionResult> Put(int id, [FromBody] BlogDtoCreate blog)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
             var currentUser = await _userManager.FindByNameAsync(User.Identity.Name);
             return Ok(await _blogService.UpdateAsync(id, blog, currentUser.Id));
         }

--- a/BlogApp.Api/Controllers/CommentController.cs
+++ b/BlogApp.Api/Controllers/CommentController.cs
@@ -33,6 +33,10 @@ namespace BlogApp.Api.Controllers
         [HttpPost("{blogId}")]
         public async Task<IActionResult> Post(int blogId, [FromBody] CommentDtoCreate commentDto)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
             var blog = await _blogService.GetByIdAsync(blogId);
             if (blog == null)
             {
@@ -46,6 +50,10 @@ namespace BlogApp.Api.Controllers
         [HttpPut("{blogId}/{id}")]
         public async Task<IActionResult> Put(int blogId, int id, [FromBody] CommentDtoCreate commentDto)
         {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
             var blog = await _blogService.GetByIdAsync(blogId);
             if (blog == null)
             {

--- a/BlogApp.Domain/Dtos/BlogDto.cs
+++ b/BlogApp.Domain/Dtos/BlogDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlogApp.Domain.Dtos
+using System.ComponentModel.DataAnnotations;
+
+namespace BlogApp.Domain.Dtos
 {
     public class BlogDto : BlogDtoCreate
     {
@@ -10,8 +12,12 @@
 
     public class BlogDtoCreate
     {
+        [Required]
         public string Name { get; set; }
+
+        [Required]
         public string Content { get; set; }
+
         public List<TagDto> Tags { get; set; }
     }
 }

--- a/BlogApp.Domain/Dtos/CommentDto.cs
+++ b/BlogApp.Domain/Dtos/CommentDto.cs
@@ -1,4 +1,6 @@
-﻿namespace BlogApp.Domain.Dtos
+using System.ComponentModel.DataAnnotations;
+
+namespace BlogApp.Domain.Dtos
 {
     public class CommentDto : CommentDtoCreate
     {
@@ -9,6 +11,7 @@
 
     public class CommentDtoCreate
     {
+        [Required]
         public string Content { get; set; }
     }
 }

--- a/BlogApp.Domain/Dtos/LoginRequestDto.cs
+++ b/BlogApp.Domain/Dtos/LoginRequestDto.cs
@@ -1,8 +1,13 @@
-﻿namespace BlogApp.Domain.Dtos
+using System.ComponentModel.DataAnnotations;
+
+namespace BlogApp.Domain.Dtos
 {
     public class LoginRequestDto
     {
+        [Required]
         public string Username { get; set; }
+
+        [Required]
         public string Password { get; set; }
     }
 }

--- a/BlogApp.Domain/Dtos/RegisterRequestDto.cs
+++ b/BlogApp.Domain/Dtos/RegisterRequestDto.cs
@@ -1,10 +1,20 @@
-﻿namespace BlogApp.Domain.Dtos
+using System.ComponentModel.DataAnnotations;
+
+namespace BlogApp.Domain.Dtos
 {
     public class RegisterRequestDto
     {
+        [Required]
         public string Firstname { get; set; }
+
+        [Required]
         public string Lastname { get; set; }
+
+        [Required]
         public string Username { get; set; }
+
+        [Required]
+        [MinLength(6)]
         public string Password { get; set; }
     }
 }

--- a/BlogApp.Domain/Dtos/TagDto.cs
+++ b/BlogApp.Domain/Dtos/TagDto.cs
@@ -1,7 +1,10 @@
-﻿namespace BlogApp.Domain.Dtos
+using System.ComponentModel.DataAnnotations;
+
+namespace BlogApp.Domain.Dtos
 {
     public class TagDto
     {
+        [Required]
         public string Name { get; set; }
     }
 }

--- a/BlogApp.UnitTests/BlogApp.UnitTests.csproj
+++ b/BlogApp.UnitTests/BlogApp.UnitTests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BlogApp.Core\BlogApp.Core.csproj" />
+    <ProjectReference Include="..\BlogApp.Api\BlogApp.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BlogApp.UnitTests/ControllerValidationTests.cs
+++ b/BlogApp.UnitTests/ControllerValidationTests.cs
@@ -1,0 +1,74 @@
+using BlogApp.Api.Controllers;
+using BlogApp.Core.Services;
+using BlogApp.Domain.Dtos;
+using BlogApp.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace BlogApp.UnitTests
+{
+    public class ControllerValidationTests
+    {
+        private Mock<UserManager<ApplicationUser>> GetUserManagerMock()
+        {
+            var store = new Mock<IUserStore<ApplicationUser>>();
+            return new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
+        }
+
+        [Fact]
+        public async Task Login_InvalidModel_ReturnsBadRequest()
+        {
+            var userManager = GetUserManagerMock();
+            var jwtService = new Mock<IJwtService>();
+            var controller = new AuthController(userManager.Object, jwtService.Object);
+            controller.ModelState.AddModelError("Username", "Required");
+
+            var result = await controller.Login(new LoginRequestDto());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Register_InvalidModel_ReturnsBadRequest()
+        {
+            var userManager = GetUserManagerMock();
+            var jwtService = new Mock<IJwtService>();
+            var controller = new AuthController(userManager.Object, jwtService.Object);
+            controller.ModelState.AddModelError("Username", "Required");
+
+            var result = await controller.Register(new RegisterRequestDto());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task BlogPost_InvalidModel_ReturnsBadRequest()
+        {
+            var blogService = new Mock<IBlogService>();
+            var commentService = new Mock<ICommentService>();
+            var userManager = GetUserManagerMock();
+            var controller = new BlogController(blogService.Object, commentService.Object, userManager.Object);
+            controller.ModelState.AddModelError("Name", "Required");
+
+            var result = await controller.Post(new BlogDtoCreate());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task CommentPost_InvalidModel_ReturnsBadRequest()
+        {
+            var blogService = new Mock<IBlogService>();
+            var commentService = new Mock<ICommentService>();
+            var userManager = GetUserManagerMock();
+            var controller = new CommentController(blogService.Object, commentService.Object, userManager.Object);
+            controller.ModelState.AddModelError("Content", "Required");
+
+            var result = await controller.Post(1, new CommentDtoCreate());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce validation on DTOs with `[Required]` and other attributes
- validate ModelState in API controllers returning `BadRequest` when invalid
- add controller unit tests to ensure validation paths work
- reference API project in test project

## Testing
- `dotnet test BlogApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_6841c5e606d4833181081c5cb5b1039a