### PR TITLE
Add subscription paywall with daily post limit

### DIFF
--- a/BlogApp.Api/BlogApp.Api.csproj
+++ b/BlogApp.Api/BlogApp.Api.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.1.0" />
+    <PackageReference Include="Stripe.net" Version="40.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlogApp.Api/Controllers/SubscriptionController.cs
+++ b/BlogApp.Api/Controllers/SubscriptionController.cs
@@ -1,0 +1,83 @@
+using BlogApp.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Stripe;
+using Stripe.Checkout;
+
+namespace BlogApp.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController, Authorize]
+    public class SubscriptionController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IConfiguration _configuration;
+
+        public SubscriptionController(UserManager<ApplicationUser> userManager, IConfiguration configuration)
+        {
+            _userManager = userManager;
+            _configuration = configuration;
+        }
+
+        [HttpGet("check")]
+        public async Task<IActionResult> CheckLimit()
+        {
+            var user = await _userManager.FindByNameAsync(User.Identity!.Name);
+            if (user == null)
+                return Unauthorized();
+
+            var limitReached = !user.SubscriptionActive && user.LastPostDate.Date == DateTime.UtcNow.Date && user.PostCount >= 1;
+            return Ok(new { limitReached, user.SubscriptionActive });
+        }
+
+        [HttpPost("create-session")]
+        public IActionResult CreateCheckoutSession()
+        {
+            var domain = _configuration["AppUrl"] ?? string.Empty;
+            StripeConfiguration.ApiKey = _configuration["Stripe:SecretKey"];
+            
+            var options = new SessionCreateOptions
+            {
+                Mode = "subscription",
+                SuccessUrl = domain + "/success",
+                CancelUrl = domain + "/cancel",
+                ClientReferenceId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value,
+                LineItems = new List<SessionLineItemOptions>
+                {
+                    new SessionLineItemOptions
+                    {
+                        Price = _configuration["Stripe:PriceId"],
+                        Quantity = 1
+                    }
+                }
+            };
+            var service = new SessionService();
+            var session = service.Create(options);
+            return Ok(new { sessionId = session.Id, url = session.Url });
+        }
+
+        [AllowAnonymous]
+        [HttpPost("webhook")]
+        public async Task<IActionResult> StripeWebhook()
+        {
+            var json = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+            var stripeEvent = EventUtility.ConstructEvent(json, Request.Headers["Stripe-Signature"], _configuration["Stripe:WebhookSecret"]);
+            if (stripeEvent.Type == Events.CheckoutSessionCompleted)
+            {
+                var session = stripeEvent.Data.Object as Session;
+                var userId = session?.ClientReferenceId;
+                if (!string.IsNullOrEmpty(userId))
+                {
+                    var user = await _userManager.FindByIdAsync(userId);
+                    if (user != null)
+                    {
+                        user.SubscriptionActive = true;
+                        await _userManager.UpdateAsync(user);
+                    }
+                }
+            }
+            return Ok();
+        }
+    }
+}

--- a/BlogApp.Api/Program.cs
+++ b/BlogApp.Api/Program.cs
@@ -3,6 +3,7 @@ using BlogApp.Api.Middleware;
 using BlogApp.Core;
 using BlogApp.Core.Context;
 using Microsoft.OpenApi.Models;
+using Stripe;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -45,6 +46,8 @@ builder.Services.AddSwaggerGen(option =>
         }
     });
 });
+
+Stripe.StripeConfiguration.ApiKey = builder.Configuration["Stripe:SecretKey"];
 
 var app = builder.Build();
 

--- a/BlogApp.Core/Context/AppDbContext.cs
+++ b/BlogApp.Core/Context/AppDbContext.cs
@@ -11,6 +11,8 @@ namespace BlogApp.Core.Context
         public DbSet<Comment> Comments { get; set; }
         public DbSet<BlogTag> BlogTags { get; set; }
         public DbSet<Tag> Tags { get; set; }
+        public DbSet<ApplicationUser> Users { get; set; }
+        public DbSet<ApplicationUser> Users { get; set; }
 
         DbSet<TEntity> Set<TEntity>() where TEntity : class;
 

--- a/BlogApp.Core/Migrations/20241130220000_addSubscriptionFields.Designer.cs
+++ b/BlogApp.Core/Migrations/20241130220000_addSubscriptionFields.Designer.cs
@@ -11,7 +11,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BlogApp.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241130220000_addSubscriptionFields")]
+    partial class addSubscriptionFields
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {

--- a/BlogApp.Core/Migrations/20241130220000_addSubscriptionFields.cs
+++ b/BlogApp.Core/Migrations/20241130220000_addSubscriptionFields.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BlogApp.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class addSubscriptionFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SubscriptionActive",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PostCount",
+                table: "AspNetUsers",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastPostDate",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: false,
+                defaultValueSql: "GETUTCDATE()");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubscriptionActive",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "PostCount",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastPostDate",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/BlogApp.Core/Services/BlogService.cs
+++ b/BlogApp.Core/Services/BlogService.cs
@@ -30,6 +30,22 @@ namespace BlogApp.Core.Services
 
         public async Task<BlogDto> AddAsync(BlogDtoCreate blogDto, string userId)
         {
+            var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId);
+            if (user == null)
+                throw new KeyNotFoundException("User not found");
+
+            if (!user.SubscriptionActive)
+            {
+                if (user.LastPostDate.Date == DateTime.UtcNow.Date && user.PostCount >= 1)
+                    throw new InvalidOperationException("Daily post limit reached");
+
+                if (user.LastPostDate.Date != DateTime.UtcNow.Date)
+                {
+                    user.PostCount = 0;
+                    user.LastPostDate = DateTime.UtcNow.Date;
+                }
+            }
+
             var blog = await _dbContext.Blogs.AddAsync(new Blog()
             {
                 Content = blogDto.Content,
@@ -37,6 +53,13 @@ namespace BlogApp.Core.Services
                 Name = blogDto.Name,
                 UserId = userId
             });
+
+            if (!user.SubscriptionActive)
+            {
+                user.PostCount += 1;
+                user.LastPostDate = DateTime.UtcNow.Date;
+            }
+
             await _dbContext.SaveChangesAsync();
 
             var createdBlogDto = _mapper.Map<BlogDto>(blog.Entity);

--- a/BlogApp.Domain/Entities/ApplicationUser.cs
+++ b/BlogApp.Domain/Entities/ApplicationUser.cs
@@ -6,5 +6,9 @@ namespace BlogApp.Domain.Entities
     {
         public string Firstname { get; set; }
         public string Lastname { get; set; }
+
+        public bool SubscriptionActive { get; set; }
+        public DateTime LastPostDate { get; set; }
+        public int PostCount { get; set; }
     }
 }

--- a/BlogApp/Pages/Blogs/CreateBlog.razor
+++ b/BlogApp/Pages/Blogs/CreateBlog.razor
@@ -23,12 +23,29 @@ else
     </MudPaper>
 }
 
+@if(showPaywall)
+{
+    <MudDialog @bind-Visible="showPaywall" Options="_dialogOptions">
+        <TitleContent>
+            <MudText Typo="Typo.h6">Subscription Required</MudText>
+        </TitleContent>
+        <DialogContent>
+            <MudText>You have reached your daily limit. Subscribe for €5/month to continue posting.</MudText>
+        </DialogContent>
+        <DialogActions>
+            <MudButton OnClick="StartCheckout" Color="Color.Primary">Subscribe</MudButton>
+            <MudButton OnClick="@(() => showPaywall = false)">Close</MudButton>
+        </DialogActions>
+    </MudDialog>
+}
+
 @code {
 
 
     [Inject] private HttpClient _httpClient { get; set; }
     [Inject] ILocalStorageService _localStorage { get; set; }
     [Inject] private ISnackbar _snackbar { get; set; }
+    [Inject] private NavigationManager NavigationManager { get; set; }
 
     [Parameter] public EventCallback OnTrigger { get; set; }
 
@@ -36,7 +53,21 @@ else
     private string blogTitle = string.Empty;
     private string blogContent = string.Empty;
     private bool loadingSubmit = false;
+    private bool showPaywall = false;
+    private string checkoutUrl = string.Empty;
+    private readonly DialogOptions _dialogOptions = new() { FullWidth = true, CloseButton = true, Position = DialogPosition.Center };
 
+
+    private async Task<bool> CheckLimitAsync()
+    {
+        var token = await _localStorage.GetItemAsync<string>("authToken");
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/subscription/check");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await _httpClient.SendAsync(request);
+        if(!resp.IsSuccessStatusCode) return true;
+        var result = await resp.Content.ReadFromJsonAsync<LimitDto>();
+        return !result!.limitReached;
+    }
 
     private async Task CreateBlogPostAsync()
     {
@@ -84,7 +115,31 @@ else
         await form.Validate();
         if (form.IsValid)
         {
-            await CreateBlogPostAsync();
+            if (await CheckLimitAsync())
+            {
+                await CreateBlogPostAsync();
+            }
+            else
+            {
+                showPaywall = true;
+            }
         }
     }
+
+    private async Task StartCheckout()
+    {
+        var token = await _localStorage.GetItemAsync<string>("authToken");
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/subscription/create-session");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var resp = await _httpClient.SendAsync(req);
+        if(resp.IsSuccessStatusCode)
+        {
+            var result = await resp.Content.ReadFromJsonAsync<CheckoutDto>();
+            checkoutUrl = result!.url;
+            NavigationManager.NavigateTo(checkoutUrl, true);
+        }
+    }
+
+    record LimitDto(bool limitReached, bool subscriptionActive);
+    record CheckoutDto(string sessionId, string url);
 }


### PR DESCRIPTION
## Summary
- track subscription and daily post data on `ApplicationUser`
- enforce daily post limit in `BlogService`
- expose new `SubscriptionController` for limit checks and Stripe checkout
- add new migration for subscription fields
- integrate paywall modal into `CreateBlog.razor`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c76759f0833195f3cb979dfa4e22