### PR TITLE
Refine blog UI and integrate backend auth

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,64 @@
 .container {
-  padding: 1rem;
-  max-width: 36rem;
-  margin: 0 auto;
+  max-width: 42rem;
+  margin: 2rem auto;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
+
 .heading {
-  font-size: 1.5rem;
+  font-size: 2rem;
   font-weight: bold;
-  margin-bottom: 1rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
+  color: #1f2937;
 }
+
 .form {
-  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
 }
+
 .form input {
-  border: 1px solid #ccc;
-  padding: 0.25rem 0.5rem;
+  border: 1px solid #d1d5db;
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 1rem;
   width: 100%;
   box-sizing: border-box;
 }
+
 .button {
-  background-color: #1d4ed8;
+  background-color: #2563eb;
   color: #fff;
-  padding: 0.25rem 1rem;
-  border-radius: 0.25rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.375rem;
   border: none;
   cursor: pointer;
+  align-self: flex-start;
 }
+
 .list {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
+
 .list-item {
-  border: 1px solid #ccc;
-  padding: 0.5rem;
-  border-radius: 0.25rem;
-  margin-bottom: 0.5rem;
+  background: #f9fafb;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
+
 .tags {
   font-size: 0.875rem;
   color: #6b7280;
+  margin-top: 0.5rem;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,34 +1,61 @@
 import { useEffect, useState } from 'react'
-import { fetchBlogs, createBlog } from './api'
+import { fetchBlogs, createBlog, login, setAuthToken } from './api'
+import Login from './Login'
 import './App.css'
 
 function App() {
   const [blogs, setBlogs] = useState([])
   const [title, setTitle] = useState('')
   const [tags, setTags] = useState('')
+  const [token, setToken] = useState(localStorage.getItem('token') || '')
 
   useEffect(() => {
-    fetchBlogs().then(setBlogs).catch(console.error)
-  }, [])
+    if (token) {
+      setAuthToken(token)
+      fetchBlogs().then(setBlogs).catch(console.error)
+    }
+  }, [token])
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const blog = await createBlog({ title, tags: tags.split(',').map(t => t.trim()) })
+    const blog = await createBlog({
+      title,
+      tags: tags.split(',').map((t) => t.trim()),
+    })
     setBlogs([...blogs, blog])
     setTitle('')
     setTags('')
+  }
+
+  const handleLogin = async (credentials) => {
+    const t = await login(credentials)
+    setToken(t)
+  }
+
+  if (!token) {
+    return <Login onLogin={handleLogin} />
   }
 
   return (
     <div className="container">
       <h1 className="heading">Blogs</h1>
       <form onSubmit={handleSubmit} className="form">
-        <input placeholder="Title" value={title} onChange={e => setTitle(e.target.value)} />
-        <input placeholder="Tags comma separated" value={tags} onChange={e => setTags(e.target.value)} />
-        <button className="button" type="submit">Create</button>
+        <input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          placeholder="Tags comma separated"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+        <button className="button" type="submit">
+          Create
+        </button>
       </form>
       <ul className="list">
-        {blogs.map(b => (
+        {blogs.map((b) => (
           <li key={b.id} className="list-item">
             <h2>{b.title}</h2>
             {b.tags && <p className="tags">Tags: {b.tags.join(', ')}</p>}

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import './App.css'
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    await onLogin({ username, password })
+    setUsername('')
+    setPassword('')
+  }
+
+  return (
+    <div className="container">
+      <h1 className="heading">Login</h1>
+      <form onSubmit={handleSubmit} className="form">
+        <input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="button" type="submit">
+          Login
+        </button>
+      </form>
+    </div>
+  )
+}
+
+export default Login
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,34 @@
 const API_BASE = '/api';
 
-export async function fetchBlogs() {
-  const res = await fetch(`${API_BASE}/blog`);
+let authToken = localStorage.getItem('token') || '';
+
+export function setAuthToken(token) {
+  authToken = token;
+  if (token) {
+    localStorage.setItem('token', token);
+  } else {
+    localStorage.removeItem('token');
+  }
+}
+
+function authHeader() {
+  return authToken ? { 'Authorization': `Bearer ${authToken}` } : {};
+}
+
+export async function login(credentials) {
+  const res = await fetch(`${API_BASE}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(credentials)
+  });
+  if (!res.ok) throw new Error('Failed to login');
+  return res.text();
+}
+
+export async function fetchBlogs(page = 1, pageSize = 10) {
+  const res = await fetch(`${API_BASE}/blog/${page}/${pageSize}`, {
+    headers: authHeader()
+  });
   if (!res.ok) throw new Error('Failed to fetch');
   return res.json();
 }
@@ -9,9 +36,7 @@ export async function fetchBlogs() {
 export async function createBlog(data) {
   const res = await fetch(`${API_BASE}/blog`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(data)
   });
   if (!res.ok) throw new Error('Failed to create');

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,4 +2,6 @@ body {
   font-family: system-ui, sans-serif;
   margin: 0;
   padding: 0;
+  background: #f3f4f6;
+  color: #111827;
 }


### PR DESCRIPTION
## Summary
- add login flow and JWT token handling
- connect blog operations to backend API with auth
- refresh styles for a cleaner layout

## Testing
- `npm run lint`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4907425008331a563eea266b5aea8